### PR TITLE
Update README to drive Quaddle Kickstarter prelaunch signups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCat
 
-**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle! For the latest OpenCat robots (Bittle X, Nybble Q), see [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot).**
+**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle! For the latest OpenCat robots (Bittle X, Nybble Q), see [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), or buy [Bittle X on Amazon](https://www.amazon.com/dp/B0FNT6TSVT?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-amazon-buy-link).**
 
 ![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/run.gif?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ In the **Wiki** tab, there's a slow documenting process going on.
 
 We just acquired our official domain: www.petoi.com. You can subscribe for our official newsletters.
 
-Random updates will be posted on Twitter [@PetoiCamp](https://twitter.com/petoicamp), Instagram [@petoicamp](https://www.instagram.com/petoicamp/), and [YouTube channel](https://www.youtube.com/@petoicamp)
+Random updates will be posted on Twitter [@PetoiCamp](https://twitter.com/petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-twitter-follow), Instagram [@petoicamp](https://www.instagram.com/petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-instagram-follow), and [YouTube channel](https://www.youtube.com/@petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-youtube-follow)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCat
 
-**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle!**
+**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle! For the latest OpenCat robots (Bittle X, Nybble Q), see [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot).**
 
 ![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/run.gif?raw=true)
 
@@ -10,12 +10,32 @@
 
 This is the repository for OpenCat project. 
 
-The goal is to collaborate talents for this cute quadruped robot. It's still a complex system only for skilled makers, yet we want to share it with the public by mass production and bringing down the cost. 
+The goal is to collaborate talents for this cute quadruped mini robot kit. It's still a complex system only for skilled makers, yet we want to share it with the public by mass production and bringing down the cost. 
+
+OpenCat robots are used for hands-on **physical AI education** and real-world **physical AI applications** — from K-12 robotics classrooms to university research labs — not just screen-based coding exercises.
+
+## Coming Soon: Quaddle mini robot dog
+![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/quaddleCover.gif?raw=true)
+
+[Quaddle](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-quaddle-section) is Petoi's newest quadruped, launching on Kickstarter **August 2026** — a mini desk robot built on the same OpenCat lineage as Bittle and Nybble. What makes it worth a look: it's a full quadruped running on just 4 servos instead of the usual 8–12, which forces genuinely different gait-design and leg-coordination solutions to still get all four legs walking, running, and balancing. Its servos are also position-feedback — readable, not just drivable — which is what makes Puppet Mode possible: hand-guide the legs and record a motion directly, no code required to capture a new behavior. We'll also share 3D-printable shells and mounts for customization. Same open platform this codebase's lineage already supports for gait research, RL, and sim2real work — a hands-on physical AI platform, not a toy version of the idea.
+
+**Source code is not yet public.** It's an upgraded version of the OpenCat project. Its ESP32-S3 code structure is closer to [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), which already powers thousands of Bittle X and Nybble Q robots in the field, than to this legacy repo. We plan to open source it before Quaddle delivery. Watch [r/petoi](https://www.reddit.com/r/Petoi/) for the announcement, or [reserve a spot](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-reserve-spot-link) to get notified at launch.
+
+## About the Founder & Track Record
+
+Inspired by Boston Dynamics' Spot, [Dr. Rongzhong Li](https://www.linkedin.com/in/rongzhongli/) started OpenCat in his dorm at Wake Forest University in 2016. The goal was straightforward: make agile quadruped robots affordable and hackable enough for researchers, educators, and makers — not just well-funded labs.
+
+Since then:
+- **30,000+ robots shipped**, cumulative across all channels
+- **60+ countries**
+- **$1M+ raised** across two prior Kickstarter and Indiegogo campaigns
+- **20+ academic papers** cite the platform — see [Research Spotlight](https://www.petoi.com/pages/robotics-research-and-academic-applications?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
+- One of the most-starred open-source quadruped robot projects on GitHub
 
 In the **Wiki** tab, there's a slow documenting process going on. 
 
 We just acquired our official domain: www.petoi.com. You can subscribe for our official newsletters.
 
-Random updates will be posted on Twitter [@PetoiCamp](https://twitter.com/petoicamp), Instagram [@Petoi_Camp](https://www.instagram.com/petoi_camp/), and [YouTube channel](https://www.youtube.com/c/rongzhongli)
+Random updates will be posted on Twitter [@PetoiCamp](https://twitter.com/petoicamp), Instagram [@petoicamp](https://www.instagram.com/petoicamp/), and [YouTube channel](https://www.youtube.com/@petoicamp)
 
 


### PR DESCRIPTION
## Summary
- Adds a Quaddle CTA with dedicated UTM tracking, founder-credibility stats, and physical AI education/applications keyword coverage to this legacy repo.
- Adds a pointer to OpenCatESP32 for current-gen hardware (Bittle X, Nybble Q), alongside the existing pointer to the main OpenCat repo.
- Fixes outdated Instagram (`@petoi_camp` → `@petoicamp`) and YouTube (personal channel → official `@petoicamp` channel) social handles.

## Test plan
- [x] Verified all links in the file resolve (200/redirect, no 404s)
- [x] Confirmed UTM `utm_content` values are unique for signup-source attribution