### PR TITLE
Update Quaddle Kickstarter link, buy link, and social follow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCat
 
-**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle! For the latest OpenCat robots (Bittle X, Nybble Q), see [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), or buy [Bittle X on Amazon](https://www.amazon.com/dp/B0FNT6TSVT?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-amazon-buy-link).**
+**This repository for Nybble is too redundent with large image files and is now obsolete. Please visit our [new repository for OpenCat](https://github.com/PetoiCamp/OpenCat) that works for both Nybble and Bittle! For the latest OpenCat robots (Bittle X, Nybble Q), see [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), or buy [Bittle X on Petoi.com](https://www.petoi.com/shop?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-shop-buy-link).**
 
 ![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/run.gif?raw=true)
 
@@ -14,12 +14,22 @@ The goal is to collaborate talents for this cute quadruped mini robot kit. It's 
 
 OpenCat robots are used for hands-on **physical AI education** and real-world **physical AI applications** — from K-12 robotics classrooms to university research labs — not just screen-based coding exercises.
 
-## Coming Soon: Quaddle mini robot dog
+## Quaddle mini robot dog — launching on Kickstarter Sept 2, 2026
 ![](https://github.com/PetoiCamp/NonCodeFiles/blob/master/gif/quaddleCover.gif?raw=true)
 
-[Quaddle](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-quaddle-section) is Petoi's newest quadruped, launching on Kickstarter **August 2026** — a mini desk robot built on the same OpenCat lineage as Bittle and Nybble. What makes it worth a look: it's a full quadruped running on just 4 servos instead of the usual 8–12, which forces genuinely different gait-design and leg-coordination solutions to still get all four legs walking, running, and balancing. Its servos are also position-feedback — readable, not just drivable — which is what makes Puppet Mode possible: hand-guide the legs and record a motion directly, no code required to capture a new behavior. We'll also share 3D-printable shells and mounts for customization. Same open platform this codebase's lineage already supports for gait research, RL, and sim2real work — a hands-on physical AI platform, not a toy version of the idea.
+[Quaddle](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_quaddle-section&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-quaddle-section) is Petoi's newest quadruped, **going live on Kickstarter Sept 2, 2026** — a mini desk robot built on the same OpenCat lineage as Bittle and Nybble.
 
-**Source code is not yet public.** It's an upgraded version of the OpenCat project. Its ESP32-S3 code structure is closer to [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), which already powers thousands of Bittle X and Nybble Q robots in the field, than to this legacy repo. We plan to open source it before Quaddle delivery. Watch [r/petoi](https://www.reddit.com/r/Petoi/) for the announcement, or [reserve a spot](https://prelaunch.com/projects/petoi-quaddle-your-perfect-tinkering-companion?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-reserve-spot-link) to get notified at launch.
+- Full quadruped running on just **4 servos** instead of the usual 8–12, which forces genuinely different gait-design and leg-coordination solutions to still get all four legs walking, running, and balancing
+- Position-feedback servos — readable, not just drivable — which is what makes **Puppet Mode** possible: hand-guide the legs and record a motion directly, no code required
+- 3D-printable shells and mounts for customization
+- Same open platform this codebase's lineage already supports for gait research, reinforcement learning (RL), and sim2real work — a hands-on physical AI platform, not a toy version of the idea
+- Try it in the [online simulator](https://www.petoi.com/pages/quaddle-robot-dog-simulator?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-quaddle-simulator) before it ships
+
+**Source code is not yet public.** It's an upgraded version of the OpenCat project. Its ESP32-S3 code structure is closer to [OpenCatESP32](https://github.com/PetoiCamp/OpenCatEsp32-Quadruped-Robot), which already powers thousands of Bittle X and Nybble Q robots in the field, than to this legacy repo. We plan to open source it before Quaddle delivery.
+
+- Watch [r/petoi](https://www.reddit.com/r/Petoi/) and [Discord](https://discord.com/invite/ckdu23q8nr) for the open-source announcement
+- [Get notified on Kickstarter](https://www.kickstarter.com/projects/petoi/quaddle-open-source-desktop-robot-kit/?ref=github_opencat_notify-link&utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-notify-link) when it goes live
+- Check out the [Quaddle Hugging Face page](https://huggingface.co/petoi/quaddle)
 
 ## About the Founder & Track Record
 
@@ -32,10 +42,13 @@ Since then:
 - **20+ academic papers** cite the platform — see [Research Spotlight](https://www.petoi.com/pages/robotics-research-and-academic-applications?utm_source=github&utm_medium=code&utm_campaign=github-opencat)
 - One of the most-starred open-source quadruped robot projects on GitHub
 
-In the **Wiki** tab, there's a slow documenting process going on. 
+Follow the project:
 
-We just acquired our official domain: www.petoi.com. You can subscribe for our official newsletters.
-
-Random updates will be posted on Twitter [@PetoiCamp](https://twitter.com/petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-twitter-follow), Instagram [@petoicamp](https://www.instagram.com/petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-instagram-follow), and [YouTube channel](https://www.youtube.com/@petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-youtube-follow)
+- [YouTube](https://www.youtube.com/@petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-youtube-follow)
+- [Twitter](https://twitter.com/petoicamp?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-twitter-follow)
+- [Instagram](https://www.instagram.com/petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-instagram-follow)
+- [Facebook](https://www.facebook.com/PetoiCamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-facebook-follow)
+- [LinkedIn](https://www.linkedin.com/company/petoi/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-linkedin-follow)
+- [TikTok](https://www.tiktok.com/@petoicamp/?utm_source=github&utm_medium=code&utm_campaign=github-opencat&utm_content=old-readme-tiktok-follow)
 
 


### PR DESCRIPTION
## Summary
- Point Quaddle links to the live Kickstarter campaign (Sept 2, 2026), add Hugging Face/simulator/Discord links
- Route the Bittle X buy link to Petoi.com/shop instead of Amazon
- Replace the outdated Wiki/domain-acquisition note with an updated social follow list (adds Facebook, LinkedIn, TikTok)

## Test plan
- [x] Verified no leftover prelaunch/reserve/August 2026 references remain
- [ ] Preview rendered README on GitHub